### PR TITLE
build(ci/cd): run on all branches

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - '*'
   pull_request:
-    branches: [main]
+    branches:
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
Prior to this commit, ci cd workflow will only run on branch `main`, this commit make them run on every branches.