### PR TITLE
build(ci/cd): update actions version

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.2.0
       - name: Install Dependencies
         run: npm install
       - name: Build
@@ -19,7 +19,7 @@ jobs:
   prettier-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.2.0
       - name: Install Dependencies
         run: npm install
       - name: Prettier Check
@@ -28,7 +28,7 @@ jobs:
   eslint-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.2.0
       - name: Install Dependencies
         run: npm install
       - name: ESLint Check


### PR DESCRIPTION
Node.js 12 actions are deprecated. Update the version actions/checkout@v2 to actions/checkout@v3.2.0.
More information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/