### PR TITLE
fix(index): `xs` size will ruin ui

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,7 +41,7 @@ export default function Home(): JSX.Element {
           />
         </Grid>
       )}
-      <Grid item xs={12} md lg>
+      <Grid item xs md lg>
         <Stack alignItems="center" spacing={10} divider={<Divider flexItem />} sx={{ p: 2 }}>
           <AboutMeSection ref={aboutMeRef} />
           <ExperienceSection ref={experienceRef} />


### PR DESCRIPTION
The reason is I forget to update the `xs` size for sections after updating total columns from `12` to `24`.